### PR TITLE
Add initial inotify exporter implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+
+go:
+- '1.8'
+
+# Unconditionally place the repo at GOPATH/src/${go_import_path} to support
+# forks.
+go_import_path: github.com/m-lab/inotify-exporter
+
+
+before_install:
+- go get github.com/mattn/goveralls
+- go get github.com/wadey/gocovmerge
+
+script:
+# Run query "unit tests".
+- go test -v -covermode=count -coverprofile=watch.cov github.com/m-lab/inotify-exporter/watch
+
+# Coveralls
+- $HOME/gopath/bin/gocovmerge watch.cov > merge.cov
+- $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci

--- a/cmd/inotify_exporter/main.go
+++ b/cmd/inotify_exporter/main.go
@@ -74,10 +74,10 @@ func init() {
 	flag.StringArrayVar(&rootPaths, "path", nil, "Path of root directory to watch.")
 }
 
-// onEvent processes a single inotify event. Only file events are considered.
-// shortPath should be relative to the base directory of inotify watch. The
-// prefix of shortPath should match the pattern: YYYY/MM/DD.
-func onEvent(t time.Time, ev notify.EventInfo, shortPath string) {
+// updateMetrics processes a single inotify event. Meant to be used with
+// watch.DirRecursively. On every file event, updateMetrics increments the
+// prometheus file extension counters.
+func updateMetrics(t time.Time, ev notify.EventInfo, shortPath string) {
 	// The event is for a file under a YYYY/MM/DD/* prefix.
 	switch ev.Event() {
 	case notify.InCreate:
@@ -112,7 +112,7 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.LUTC)
 	for _, path := range rootPaths {
 		log.Printf("Adding watch: %s\n", path)
-		go watch.DirRecursively(path, stop, onEvent)
+		go watch.DirRecursively(path, stop, updateMetrics)
 	}
 
 	// The Handler function provides a default handler to expose metrics

--- a/cmd/inotify_exporter/main.go
+++ b/cmd/inotify_exporter/main.go
@@ -1,0 +1,139 @@
+// Copyright 2017 inotify-exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// inotify_exporter monitors file creation, deletion, and other events within
+// an M-Lab experiment data directory. Aggregate event counts are exported for
+// Prometheus monitoring. These events may be logged for offline auditing.
+package main
+
+import (
+	"log"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/rjeczalik/notify"
+	flag "github.com/spf13/pflag"
+
+	"github.com/m-lab/inotify-exporter/watch"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	rootPaths = []string{}
+)
+
+// Prometheus Metrics.
+var (
+	createCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "inotify_file_create_total",
+		Help: "A running count of all files created in watched directories.",
+	})
+	// createExtensions.WithLabelValues("s2c_snaplog").Inc()
+	createExtensions = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "inotify_extension_create_total",
+			Help: "A running count of file extensions created in watched directories.",
+		},
+		[]string{"ext"},
+	)
+	deleteCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "inotify_file_delete_total",
+		Help: "A running count of all files deleted from watched directories.",
+	})
+	deleteExtensions = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "inotify_extension_delete_total",
+			Help: "A running count of file extensions deleted from watched directories.",
+		},
+		[]string{"ext"},
+	)
+	closeWriteCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "inotify_file_closewrite_total",
+		Help: "A running count of all files with closewrite events in watched directories.",
+	})
+	closeWriteExtensions = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "inotify_extension_closewrite_total",
+			Help: "A running count of file extensions with closewrite events in watched directories.",
+		},
+		[]string{"ext"},
+	)
+)
+
+func init() {
+	// Metrics have to be registered to be exposed:
+	prometheus.MustRegister(createCount)
+	prometheus.MustRegister(createExtensions)
+	prometheus.MustRegister(deleteCount)
+	prometheus.MustRegister(deleteExtensions)
+	prometheus.MustRegister(closeWriteCount)
+	prometheus.MustRegister(closeWriteExtensions)
+
+	// Flags.
+	flag.StringArrayVar(&rootPaths, "path", nil, "Path of root directory to watch.")
+}
+
+// onEvent processes a single inotify event. Only file events are considered.
+// shortPath should be relative to the base directory of inotify watch. The
+// prefix of shortPath should match the pattern: YYYY/MM/DD.
+func onEvent(t time.Time, ev notify.EventInfo, shortPath string) {
+	// The event is for a file under a YYYY/MM/DD/* prefix.
+	switch ev.Event() {
+	case notify.InCreate:
+		createCount.Inc()
+		createExtensions.WithLabelValues(getExtension(ev.Path())).Inc()
+	case notify.InDelete:
+		deleteCount.Inc()
+		deleteExtensions.WithLabelValues(getExtension(ev.Path())).Inc()
+	case notify.InCloseWrite:
+		closeWriteCount.Inc()
+		closeWriteExtensions.WithLabelValues(getExtension(ev.Path())).Inc()
+	default:
+		// No change.
+	}
+	return
+}
+
+// getExtension extracts the filename extension and if it ends with .gz,
+// returns the last two extensions.
+func getExtension(filename string) string {
+	if strings.HasSuffix(filename, ".gz") {
+		// Extract the preceeding extension if the file ends with .gz.
+		return path.Ext(filename[:len(filename)-3]) + ".gz"
+	} else {
+		return path.Ext(filename)
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	// Directories are watched indefinitely, so this is never used.
+	stop := make(chan bool)
+
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.LUTC)
+	for _, path := range rootPaths {
+		log.Printf("Adding watch: %s\n", path)
+		go watch.DirRecursively(path, stop, onEvent)
+	}
+
+	// The Handler function provides a default handler to expose metrics
+	// via an HTTP server. "/metrics" is the usual endpoint for that.
+	http.Handle("/metrics", promhttp.Handler())
+	log.Fatal(http.ListenAndServe(":9393", nil))
+}

--- a/cmd/inotify_exporter/main.go
+++ b/cmd/inotify_exporter/main.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	// TODO: add vendor support for github.com/rjeczalik/notify
 	"github.com/rjeczalik/notify"
 	flag "github.com/spf13/pflag"
 
@@ -117,5 +118,7 @@ func main() {
 	// The Handler function provides a default handler to expose metrics
 	// via an HTTP server. "/metrics" is the usual endpoint for that.
 	http.Handle("/metrics", promhttp.Handler())
+
+	// TODO: use a port that won't conflict with registered exporter ports.
 	log.Fatal(http.ListenAndServe(":9393", nil))
 }

--- a/cmd/inotify_exporter/main.go
+++ b/cmd/inotify_exporter/main.go
@@ -107,7 +107,7 @@ func main() {
 	flag.Parse()
 
 	// Directories are watched indefinitely, so this is never used.
-	stop := make(chan bool)
+	stop := make(chan struct{})
 
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.LUTC)
 	for _, path := range rootPaths {

--- a/cmd/inotify_exporter/main.go
+++ b/cmd/inotify_exporter/main.go
@@ -39,10 +39,6 @@ var (
 
 // Prometheus Metrics.
 var (
-	createCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "inotify_file_create_total",
-		Help: "A running count of all files created in watched directories.",
-	})
 	// createExtensions.WithLabelValues("s2c_snaplog").Inc()
 	createExtensions = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -51,10 +47,6 @@ var (
 		},
 		[]string{"ext"},
 	)
-	deleteCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "inotify_file_delete_total",
-		Help: "A running count of all files deleted from watched directories.",
-	})
 	deleteExtensions = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "inotify_extension_delete_total",
@@ -62,10 +54,6 @@ var (
 		},
 		[]string{"ext"},
 	)
-	closeWriteCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "inotify_file_closewrite_total",
-		Help: "A running count of all files with closewrite events in watched directories.",
-	})
 	closeWriteExtensions = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "inotify_extension_closewrite_total",
@@ -77,11 +65,8 @@ var (
 
 func init() {
 	// Metrics have to be registered to be exposed:
-	prometheus.MustRegister(createCount)
 	prometheus.MustRegister(createExtensions)
-	prometheus.MustRegister(deleteCount)
 	prometheus.MustRegister(deleteExtensions)
-	prometheus.MustRegister(closeWriteCount)
 	prometheus.MustRegister(closeWriteExtensions)
 
 	// Flags.
@@ -95,13 +80,10 @@ func onEvent(t time.Time, ev notify.EventInfo, shortPath string) {
 	// The event is for a file under a YYYY/MM/DD/* prefix.
 	switch ev.Event() {
 	case notify.InCreate:
-		createCount.Inc()
 		createExtensions.WithLabelValues(getExtension(ev.Path())).Inc()
 	case notify.InDelete:
-		deleteCount.Inc()
 		deleteExtensions.WithLabelValues(getExtension(ev.Path())).Inc()
 	case notify.InCloseWrite:
-		closeWriteCount.Inc()
 		closeWriteExtensions.WithLabelValues(getExtension(ev.Path())).Inc()
 	default:
 		// No change.

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -25,7 +25,10 @@ var (
 
 // DirRecursively starts a recursive inotify watch on InCreate, InDelete, and
 // InCloseWrite events on baseDir and subdirectories. The watch will remain
-// active until the caller sends a value to the stop channel.
+// active until the caller closes the stop channel. DirRecursively calls
+// onEvent for events on files (not directories) that are under a directory
+// structure matching the pattern YYYY/MM/DD/*. Directory events or files in
+// other locations are ignored.
 func DirRecursively(baseDir string, stop <-chan struct{},
 	onEvent func(t time.Time, ev notify.EventInfo, shortPath string)) error {
 	// Notify will drop events if the receiver does not keep up. So, make the

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	// TODO: add vendor support for github.com/rjeczalik/notify
 	"github.com/rjeczalik/notify"
 )
 
@@ -25,7 +26,7 @@ var (
 // DirRecursively starts a recursive inotify watch on InCreate, InDelete, and
 // InCloseWrite events on baseDir and subdirectories. The watch will remain
 // active until the caller sends a value to the stop channel.
-func DirRecursively(baseDir string, stop <-chan bool,
+func DirRecursively(baseDir string, stop <-chan struct{},
 	onEvent func(t time.Time, ev notify.EventInfo, shortPath string)) error {
 	// Notify will drop events if the receiver does not keep up. So, make the
 	// channel buffered to ensure no event is dropped.

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -64,15 +64,13 @@ func DirRecursively(baseDir string, stop <-chan struct{},
 
 		shortPath := getPathSuffix(baseDir, ev.Path())
 		// Only accept valid YYYY/MM/DD paths.
-		if !isValidPath(shortPath) {
-			continue
+		if isValidPath(shortPath) {
+			t := time.Now().UTC()
+			log.Printf("%s %s %s\n", t, ev.Event(), ev.Path())
+			// For all file events with a valid path, call the user-provided
+			// onEvent function.
+			onEvent(t, ev, shortPath)
 		}
-
-		t := time.Now().UTC()
-		log.Printf("%s %s %s\n", t, ev.Event(), ev.Path())
-		// Process all other events, since this is a recursive watch.
-		onEvent(t, ev, shortPath)
-
 	}
 	return nil
 }

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -1,0 +1,105 @@
+// watch provides an interface for recursively watching file events under a
+// YYYY/MM/DD data directory hierarchy.
+package watch
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/rjeczalik/notify"
+)
+
+var (
+	// Patterns for matching date strings in directory names.
+	yearPattern  = `20[0-9]{2}`
+	monthPattern = `0[1-9]|1[0-2]`
+	dayPattern   = `0[1-9]|[12][0-9]|3[0-1]`
+	datePattern  = regexp.MustCompile(yearPattern + "/" + monthPattern + "/" + dayPattern)
+)
+
+// DirRecursively starts a recursive inotify watch on InCreate, InDelete, and
+// InCloseWrite events on baseDir and subdirectories. The watch will remain
+// active until the caller sends a value to the stop channel.
+func DirRecursively(baseDir string, stop <-chan bool,
+	onEvent func(t time.Time, ev notify.EventInfo, shortPath string)) error {
+	// Notify will drop events if the receiver does not keep up. So, make the
+	// channel buffered to ensure no event is dropped.
+	ch := make(chan notify.EventInfo, 128)
+
+	// Start a recursive watch on baseDir.
+	err := notify.Watch(fmt.Sprintf("%s/...", baseDir), ch,
+		notify.InCreate, notify.InDelete, notify.InCloseWrite)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+	defer notify.Stop(ch)
+
+	var ev notify.EventInfo
+	for {
+		// Receive an event from the watch channel.
+		select {
+		case ev = <-ch:
+		case <-stop:
+			// The caller has signaled us to stop.
+
+			// NOTE: the recursive behavior of notify.Watch consumes the delete
+			// directory event on the watched directory. For non-recursive
+			// behavior the delete event is sent to the channel and serves as
+			// the stop condition. This seems like a bug in the recursive
+			// implementation.
+			return nil
+		}
+
+		// Only count files.
+		if isDir(ev) {
+			continue
+		}
+
+		shortPath := getPathSuffix(baseDir, ev.Path())
+		// Only accept valid YYYY/MM/DD paths.
+		if !isValidPath(shortPath) {
+			continue
+		}
+
+		t := time.Now().UTC()
+		log.Printf("%s %s %s\n", t, ev.Event(), ev.Path())
+		// Process all other events, since this is a recursive watch.
+		onEvent(t, ev, shortPath)
+
+	}
+	return nil
+}
+
+// isDir checks whether the event applied to a directory.
+func isDir(ev notify.EventInfo) bool {
+	unixEv, ok := ev.Sys().(*unix.InotifyEvent)
+	if !ok {
+		return false
+	}
+	return unixEv.Mask&unix.IN_ISDIR != 0
+}
+
+// isValidPath checks whether the path prefix matches the YYYY/MM/DD directory pattern.
+func isValidPath(datePath string) bool {
+	if len(datePath) < 10 {
+		return false
+	}
+	return datePattern.MatchString(datePath[:10])
+}
+
+// getPathSuffix strips the prefixDir from the eventPath and returns only the
+// path suffix. If the prefixDir is not present, getPathSuffix returns the
+// empty string.
+func getPathSuffix(prefixDir, eventPath string) string {
+	// Only consider paths that are under prefix. This is a sanity check.
+	if !strings.HasPrefix(eventPath, prefixDir) {
+		return ""
+	}
+	return strings.TrimPrefix(eventPath, prefixDir+"/")
+}

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -1,0 +1,95 @@
+package watch_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/m-lab/inotify-exporter/watch"
+	"github.com/rjeczalik/notify"
+)
+
+func TestDirRecursively(t *testing.T) {
+	done := make(chan bool)
+	events := make(chan string, 20)
+	stop := make(chan bool)
+
+	// Try to watch a directory that does not exist, should return immediately.
+	err := watch.DirRecursively("DirDoesNotExist", stop,
+		func(et time.Time, ev notify.EventInfo, shortPath string) {
+			// No events should be processed.
+			t.Fatalf("%s %s %s\n", et, ev, shortPath)
+		},
+	)
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	// Create a temp, base directory for testing real file events.
+	tmpDir, err := ioutil.TempDir("", "TestDirRecursively-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an event handling function that sends all events to the events channel.
+	onEvent := func(et time.Time, ev notify.EventInfo, shortPath string) {
+		// Send the short path to the events channel.
+		t.Logf("Handling event for %s\n", shortPath)
+		events <- shortPath
+	}
+
+	// Watch a directory that does exist will block. So, run this in a go
+	// routine where we can signal that the function is 'done' after it
+	// returns.
+	go func() {
+		err := watch.DirRecursively(tmpDir, stop, onEvent)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Signal that we returned successfully.
+		done <- true
+	}()
+
+	// Create a YYYY/MM/DD directory path.
+	dateDir := tmpDir + "/2017/10/11"
+	err = os.MkdirAll(dateDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until the watch is ready. Without a delay, the notify.Watch is still
+	// initializing and the following events are missed.
+	time.Sleep(500 * time.Millisecond)
+
+	// Create a file in the tmpDir/YYYY/MM/DD directory.
+	fName := dateDir + "/" + "foo"
+	f, err := os.Create(fName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// Verify that we receive an event from onEvent above.
+	select {
+	case <-events:
+		break
+	case <-time.After(time.Second * 2):
+		t.Fatal("timeout waiting for event.")
+	}
+
+	// Send a stop signal to watch.DirRecursively so that it returns.
+	stop <- true
+
+	// Verify that watch.DirRecursively returns.
+	select {
+	case <-done:
+		t.Log("Returned successfully")
+	case <-time.After(time.Second * 2):
+		t.Fatal("timeout waiting for event.")
+	}
+}

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -13,7 +13,7 @@ import (
 func TestDirRecursively(t *testing.T) {
 	done := make(chan bool)
 	events := make(chan string, 20)
-	stop := make(chan bool)
+	stop := make(chan struct{})
 
 	// Try to watch a directory that does not exist, should return immediately.
 	err := watch.DirRecursively("DirDoesNotExist", stop,
@@ -82,8 +82,8 @@ func TestDirRecursively(t *testing.T) {
 		t.Fatal("timeout waiting for event.")
 	}
 
-	// Send a stop signal to watch.DirRecursively so that it returns.
-	stop <- true
+	// Close channel to signal stop to watch.DirRecursively so that it returns.
+	close(stop)
 
 	// Verify that watch.DirRecursively returns.
 	select {

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -82,7 +82,7 @@ func TestDirRecursively(t *testing.T) {
 		t.Fatal("timeout waiting for event.")
 	}
 
-	// Close channel to signal stop to watch.DirRecursively so that it returns.
+	// Close channel to signal watch.DirRecursively to stop, so that it returns.
 	close(stop)
 
 	// Verify that watch.DirRecursively returns.


### PR DESCRIPTION
This change adds initial .travis.yml with goveralls configuration for the watch package, and a minimal inotify_exporter command.

The command inotify_exporter is suitable for bundling with an existing experiment such as NDT to monitor the file creation, deletion, and closewrite rate for various file types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/inotify-exporter/2)
<!-- Reviewable:end -->
